### PR TITLE
Switched to a good release version of GISCore.

### DIFF
--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.opensextant</groupId>
             <artifactId>giscore</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.1</version>
             <!-- https://github.com/OpenSextant/giscore/issues/2 TODO remove once fixed-->
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
This switches the GISCore dependency to version 2.0.1 that doesn't have the problematic Ivy-style Log4J and Geodesy dependencies.
