### PR TITLE
Bumped forgotten internal dependency version numbers.

### DIFF
--- a/Extraction/pom.xml
+++ b/Extraction/pom.xml
@@ -213,7 +213,7 @@
 		<dependency>
 			<groupId>org.opensextant</groupId>
 			<artifactId>opensextant-xponents-basics</artifactId>
-			<version>2.1</version>
+			<version>2.2-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/XText/pom.xml
+++ b/XText/pom.xml
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.opensextant</groupId>
 			<artifactId>opensextant-xponents-basics</artifactId>
-			<version>2.1</version>
+			<version>2.2-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
After the last round of version bumps some of the internal dependencies between the modules were not bumped. This fixes that issue.
