### PR TITLE
Added an inversion-of-control-friendly constructor for SolrGazetteer.

### DIFF
--- a/Extraction/src/main/java/org/opensextant/extractors/geo/SolrGazetteer.java
+++ b/Extraction/src/main/java/org/opensextant/extractors/geo/SolrGazetteer.java
@@ -91,10 +91,20 @@ public class SolrGazetteer {
     /**
      * Instantiates a new solr gazetteer.
      *
-     * @throws IOException Signals that an I/O exception has occurred.
+     * @throws ConfigException Signals that a configuration exception has occurred.
      */
     public SolrGazetteer() throws ConfigException {
-        initialize();
+        this((String) null);
+    }
+    
+    /**
+     * Instantiates a new solr gazetteer with the specified Solr Home location.
+     *
+     * @param solrHome the location of solrHome.
+     * @throws ConfigException Signals that a configuration exception has occurred.
+     */
+    public SolrGazetteer(String solrHome) throws ConfigException {
+        initialize(solrHome);
     }
 
     public SolrGazetteer(SolrProxy currentIndex) throws ConfigException {
@@ -154,11 +164,11 @@ public class SolrGazetteer {
      * Cascading env variables:  First use value from constructor, 
      * then opensextant.solr, then solr.solr.home
      *
-     * @throws IOException Signals that an I/O exception has occurred.
+     * @throws ConfigException Signals that a configuration exception has occurred.
      */
-    private void initialize() throws ConfigException {
+    private void initialize(String solrHome) throws ConfigException {
 
-        solr = new SolrProxy("gazetteer");
+        solr = solrHome != null ? new SolrProxy(solrHome, "gazetteer") : new SolrProxy("gazetteer");
 
         params.set(CommonParams.Q, "*:*");
         params.set(CommonParams.FL,


### PR DESCRIPTION
I've found that it's easier to integrate the gazetteer into IoC environments like Spring or Grails if the solr home location can be provided via a constructor instead of a system property. This also helps for testing environments.